### PR TITLE
fix : fix error while push one signal notifications using external user id

### DIFF
--- a/app/Helpers/ApiHelpers.php
+++ b/app/Helpers/ApiHelpers.php
@@ -30,7 +30,7 @@ function sendNotification($body, $heading, $userId = null)
             'app_id' => env('ONESIGNAL_APP_ID'),
             'contents' => $content,
             'headings' => $headings,
-            'include_external_user_ids' => [$userId],
+            'include_external_user_ids' => ["$userId"],
             "channel_for_external_user_ids" => "push",
         ];
     } else {


### PR DESCRIPTION
fix : fix error while push one signal notifications using external user id

- add double quotes to user id to make it as string in sendNotification